### PR TITLE
登录界面回车问题

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -31,7 +31,6 @@
             v-model="loginForm.username"
             placeholder="请输入用户名"
             class="input-border"
-            @keyup.enter="submitLogin"
           >
             <i slot="prefix"> <SvgIcon icon-class="account" class="icon" /></i>
           </el-input>
@@ -42,7 +41,6 @@
             v-model="loginForm.password"
             placeholder="请输入密码"
             class="input-border"
-            @keyup.enter="submitLogin"
           >
             <i slot="prefix"> <SvgIcon icon-class="password" class="icon" /></i>
           </el-input>
@@ -52,7 +50,6 @@
           <el-button
             type="primary"
             style="width: 50%; border-radius: 12px"
-            native-type="submit"
             @click="changeApi"
             plain
             >更换端口</el-button


### PR DESCRIPTION
按enter应该是登录 而不是修改端口

## Summary by Sourcery

错误修复：
- 修复了在登录表单中按下回车键错误地触发更改端口操作而不是提交登录的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the issue where pressing enter in the login form incorrectly triggered the change port action instead of submitting the login.

</details>